### PR TITLE
Temporarily fix zeroing balances.

### DIFF
--- a/contracts/ChannelManager.sol
+++ b/contracts/ChannelManager.sol
@@ -318,10 +318,7 @@ contract ChannelManager {
         }
 
 
-        // TODO why do we transfer them nothing?
-        // zero out to avoid reentrancy
-        channel.balanceA = 0;
-        channel.balanceB = 0;
+        // TODO figure out how to solve a problem with reentrancy
         // if true, then use final state to close channel
         if (channel.tokenContract == address(0)) {
             channel.agentA.transfer(channel.balanceA);


### PR DESCRIPTION
This should make tests pass on guac side, but probably makes the
contract vulnerable to reentrancy attacks.